### PR TITLE
fix: ensure auth header set on load

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -560,13 +560,11 @@ const Homepage = () => {
 // Auth Context (simplified for this demo)
 const useAuth = () => {
   const [user, setUser] = useState(null);
-  const [token, setToken] = useState(localStorage.getItem('token'));
-
-  useEffect(() => {
-    if (token) {
-      axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-    }
-  }, [token]);
+  const initialToken = localStorage.getItem('token');
+  if (initialToken) {
+    axios.defaults.headers.common['Authorization'] = `Bearer ${initialToken}`;
+  }
+  const [token, setToken] = useState(initialToken);
 
   const login = (newToken, userData) => {
     localStorage.setItem('token', newToken);
@@ -588,11 +586,14 @@ const useAuth = () => {
 // Admin Auth Context
 const useAdminAuth = () => {
   const [admin, setAdmin] = useState(null);
-  const [adminToken, setAdminToken] = useState(localStorage.getItem('adminToken'));
+  const initialAdminToken = localStorage.getItem('adminToken');
+  if (initialAdminToken) {
+    axios.defaults.headers.common['Authorization'] = `Bearer ${initialAdminToken}`;
+  }
+  const [adminToken, setAdminToken] = useState(initialAdminToken);
 
   useEffect(() => {
     if (adminToken) {
-      axios.defaults.headers.common['Authorization'] = `Bearer ${adminToken}`;
       fetchAdminProfile();
     }
   }, [adminToken]);


### PR DESCRIPTION
## Summary
- set axios authorization header from saved tokens during auth initialization to avoid early `Not authenticated` errors
- apply same synchronous header setup for admin authentication flow

## Testing
- `cd frontend && yarn test --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b4c9ccf6108322a94a040499a5ecaa